### PR TITLE
[fix] 페이지네이션 버튼 조건 변경

### DIFF
--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -205,7 +205,7 @@ const HomePage = () => {
 
 
           {/* 페이지네이션 버튼 (양옆에 배치) */}
-          {candyList.length > 6 && (
+          {totalPages > 1 && (
             <>
               {currentPage > 0 && (
                 <button


### PR DESCRIPTION
페이지 주인이 user일 때와 아닐 때 모두 pagenation 버튼 조건이 처리될 수 있도록 `candyList.length > 6` 에서 `totalPages > 1`으로 버튼 표시 조건을 변경하였습니다. 